### PR TITLE
Fix typo in Blog.scala

### DIFF
--- a/src/main/scala/com/lucidchart/xtractexample/Blog.scala
+++ b/src/main/scala/com/lucidchart/xtractexample/Blog.scala
@@ -23,7 +23,7 @@ case class Blog(
 object Blog {
   implicit val reader: XmlReader[Blog] = (
     (__ \ "head" \ "title").read[String],
-    (__ \ "head"\ "subtitle").read[String].optional,
+    (__ \ "head" \ "subtitle").read[String].optional,
     (__ \ "head" \ "author").read[AuthorInfo],
     attribute("type")(enum(BlogType)).default(BlogType.tech),
     (__ \ "body").read[Content]


### PR DESCRIPTION
I was perusing the example and noticed a space missing, so I thought I'd fix it. 